### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/egy186/eslint-config/security/code-scanning/1](https://github.com/egy186/eslint-config/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access.  
For this workflow, the best non-breaking fix is:

- Add at workflow root (after `on` and before `jobs`):
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and read-only CI tasks (install/build/lint/test). It avoids changing job behavior while documenting and enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
